### PR TITLE
fixes a bug regarding the transform input elements

### DIFF
--- a/src/components/EntityInfos/index.js
+++ b/src/components/EntityInfos/index.js
@@ -59,9 +59,8 @@ function refineActions (props$, actions) {
 }
 
 function EntityInfos ({DOM, props$}, name = '') {
-  const state$ = model(props$)
-
   const {changeMeta$, changeTransforms$} = refineActions(props$, intent(DOM))
+  const state$ = model(props$)
   // const colorPicker = colorPickerWrapper(state$, DOM)
   const vtree$ = view(state$) // , colorPicker.DOM)
 

--- a/src/components/EntityInfos/intent.js
+++ b/src/components/EntityInfos/intent.js
@@ -1,6 +1,7 @@
 import Rx from 'rx'
 let merge = Rx.Observable.merge
 import { toRadian } from '../../utils/formatters'
+function isNumber(obj) { return !isNaN(parseFloat(obj)) }
 
 export default function intent (DOM) {
   // const addComment$ = DOM.select('.comments').events('addComment$').pluck('detail')
@@ -22,8 +23,9 @@ export default function intent (DOM) {
     .shareReplay(1)
 
   const changeTransforms$ = merge(
-    DOM.select('.transformsInput').events('change')
-  // DOM.select(".transformsInput").events('input')
+    DOM.select('.transformsInput').events('change'),
+  // DOM.select(".transformsInput").events('input'),
+    DOM.select('.transformsInput').events('blur')
   )
     .map(function (e) {
       let val = parseFloat(e.target.value)
@@ -34,6 +36,7 @@ export default function intent (DOM) {
       }
       return {val, trans, idx: parseInt(idx, 10)}
     })
+    .filter(data => isNumber(data.val))
     .distinctUntilChanged()
     // .debounce(20)
     .shareReplay(1)

--- a/src/components/EntityInfos/view.js
+++ b/src/components/EntityInfos/view.js
@@ -157,6 +157,7 @@ function transformInputs (transforms, fieldName, displayName, controlsStep, numb
         inputs.push(
           <input
             type='number'
+            lang='en'
             value={value}
             step={controlsStep}
             className={`transformsInput`}


### PR DESCRIPTION
defines an English locale that allows for both the dot as the komma as a decimal mark. Also implemented number validation. 

## How to test
- Open Jam with a model
- Start editing the model with the transform input elements
- the input elements should work with both the dot as the komma as a decimal mark (the model should not disappear or become un-selectable or something like that)
- put some letters and weird signs and see what happens
- Change the input and click somewhere else on the page to see if the input gets performed even though you didn't press enter

## How to see if Guy's bug was fixed
- Select the model
- Select the transform tool in the top left
- Change the locations of the model by editing the translation input elements
- Now select the model again (can you still select the model or did it go a-wire?)


