### PR TITLE
fix(apiEndpoint): 

### DIFF
--- a/src/drivers/youMagineDriver/index.js
+++ b/src/drivers/youMagineDriver/index.js
@@ -17,14 +17,7 @@ import {getParts, getBom, getAssemblyEntries, makeApiStreamGets, makeGetStreamFo
 // actual driver stuff
 // storage driver for YouMagine designs & data etc
 export default function makeYMDriver (httpDriver, params = {}) {
-  const defaults = {
-    apiBaseUri: 'api.youmagine.com/v1',
-    urlBase: 'https'
-  }
-  params = assign({}, defaults, params)
-  let { apiBaseUri, urlBase } = params
-  const apiEndpoint = `${urlBase}://${apiBaseUri}`
-
+  
   function youMagineStorageDriver (outgoing$) {
     // ////////////////////////
     // deal with designInfos
@@ -34,7 +27,6 @@ export default function makeYMDriver (httpDriver, params = {}) {
       .share()
 
     const apiEndpoint$ = outgoing$.pluck('data', 'apiEndpoint')
-        .startWith(apiEndpoint)
         .filter(exists)
         .shareReplay(1)
 

--- a/src/drivers/youMagineDriver/index.js
+++ b/src/drivers/youMagineDriver/index.js
@@ -17,7 +17,7 @@ import {getParts, getBom, getAssemblyEntries, makeApiStreamGets, makeGetStreamFo
 // actual driver stuff
 // storage driver for YouMagine designs & data etc
 export default function makeYMDriver (httpDriver, params = {}) {
-  
+
   function youMagineStorageDriver (outgoing$) {
     // ////////////////////////
     // deal with designInfos
@@ -36,7 +36,7 @@ export default function makeYMDriver (httpDriver, params = {}) {
       .pluck('data')
       .map(({design, authData, apiEndpoint}) => ({designId: design.id, authToken: authData.token, apiEndpoint}))
       .map(function (data) {
-        const {designId, authToken} = data
+        const {designId, authToken, apiEndpoint} = data
         const authTokenStr = `/?auth_token=${authToken}`
         const designUri = `${apiEndpoint}/designs/${designId}${authTokenStr}`
         return {

--- a/src/drivers/youMagineDriver/youMagineDriver.spec.js
+++ b/src/drivers/youMagineDriver/youMagineDriver.spec.js
@@ -9,7 +9,7 @@ describe('youMagineDriver', () => {
   it('should handle data saving', function (done) {
     this.timeout(5000)
     const saveData = {
-      apiEndpoint: 'https://api.youmagine.com/v1', 
+      apiEndpoint: 'https://api.youmagine.com/v1',
       design: {id: 1, synched: true},
       authData: {token: '42'}, // bom & parts
       bom: [{id: 0, qty: 2, phys_qty: 1}], // assemblies data

--- a/src/drivers/youMagineDriver/youMagineDriver.spec.js
+++ b/src/drivers/youMagineDriver/youMagineDriver.spec.js
@@ -9,6 +9,7 @@ describe('youMagineDriver', () => {
   it('should handle data saving', function (done) {
     this.timeout(5000)
     const saveData = {
+      apiEndpoint: 'https://api.youmagine.com/v1', 
       design: {id: 1, synched: true},
       authData: {token: '42'}, // bom & parts
       bom: [{id: 0, qty: 2, phys_qty: 1}], // assemblies data


### PR DESCRIPTION
removes useless default apiEndpoint which was adding an uneeded extra (and wrong) http request

## How to test
- Open Jam with an apiEndpoint like http://localhost:3000/?apiEndpoint=https://api-test.youmagine.com/v1&authToken=XXX&autoLoad=true&autoSave=true&designId=XXX&tools=view%2Cbom%2Cedit  (replace both XXX with correct values)
- check the outbound requests to see if there are still any going out to https://api.youmagine.com/v1
