### PR TITLE
Mirror fixes

### DIFF
--- a/src/components/webgl/GlView.js
+++ b/src/components/webgl/GlView.js
@@ -370,7 +370,7 @@ function GLView ({drivers, props$}) {
           transformControls.attach(mesh)
           transformControls.setMode(tool)
         }
-        else if (!tool && mesh)
+        else if ((!tool && mesh) || ['translate', 'rotate', 'scale'].indexOf(tool) === -1)
         { // tool is undefined, but we still had selections
           transformControls.detach(mesh)
         }

--- a/src/components/webgl/model.js
+++ b/src/components/webgl/model.js
@@ -33,145 +33,33 @@ function makeRemoteMeshVisual (meta, transform, mesh) {
     // color is stored in meta component
     mesh.material.color.set(meta.color)
 
+    // this is for mirroring
+    function isOdd (num) { return num % 2 }
 
-    console.log('transforms scale',transform.sca)
-    function mirroredAxis(t){
-      return t
-        .map(val => (val >= 0)? 0: 1 )
-    }
-    const mirrored = t =>t.map(val => val <0).reduce( (prev, curr) => prev || curr )
-
-    function isOdd(num) { return num % 2}
-
-    //this is for mirroring
-    if(!mirrored(transform.sca) && mesh.flipped && mesh.material.side === THREE.BackSide){
-      //reset mirroring
-      /*let mS = (new THREE.Matrix4()).identity()
-      const conv =[0, 5, 10]
-      mS.elements[conv[0]] = -1
-      mesh.geometry.applyMatrix(mS)
-      mesh.material.side = 0
-      mesh.flipped = false*/
-    }
-    console.log('mirrored',mirrored(transform.sca))
-    /*if(mirrored(transform.sca) ){
-
-      const flipped = mesh.flipped || [0,0,0]
-
+    function handleMirroring(){
+      let flipped = mesh.flipped || [0, 0, 0]
       let mS = (new THREE.Matrix4()).identity()
-      let inversions = 0
+      const conv = [0, 5, 10]
 
-
-      const conv =[0, 5, 10]
       transform.sca
         .map(val => val <0)
-        .forEach(function(val, index){
-          if(val && flipped[index]===0){
-            console.log('val',val, index)
+        .forEach(function (val, index) {
+          if(val && flipped[index] === 0) {
             mS.elements[conv[index]] = -1
-            inversions += 1
-          }
-        })
-      //set -1 to the corresponding axis
-      mesh.geometry.applyMatrix(mS)
-
-      console.log('inversions', inversions, 'mirroredAxis', mirroredAxis(transform.sca))
-      if(mesh.material.side != THREE.BackSide && (inversions === 1 || inversions ==3) )
-      {
-        console.log('flipping material')
-        mesh.material.side = THREE.BackSide
-      }
-
-      mesh.flipped = mirroredAxis(transform.sca)
-    }*/
-
-
-    function foo(){
-      let flipped = mesh.flipped || [0,0,0]
-
-      let mS = (new THREE.Matrix4()).identity()
-      let inversions = 0
-
-
-      const conv =[0, 5, 10]
-      transform.sca
-        .map(val => val <0)
-        .forEach(function(val, index){
-          if(val && flipped[index]===0){
-            mS.elements[conv[index]] = -1
-            inversions += 1
             flipped[index]=1
           }
           //flip back
-          if(!val && flipped[index]===1){
+          if(!val && flipped[index] === 1) {
             mS.elements[conv[index]] = -1
-            inversions += 1
             flipped[index] = 0
           }
         })
       mesh.geometry.applyMatrix(mS)
       mesh.flipped = flipped
-      inversions = flipped.reduce( (prev, curr) => prev || curr )
-
-      console.log('inversions', inversions ,flipped)
-      if(!isOdd(inversions)){
-        /*if(mesh.material.side !== THREE.BackSide){
-          mesh.material.side = THREE.BackSide
-        }else{
-          mesh.material.side = 0
-        }*/
-        mesh.material.side = 0
-      }else{
-        /*if(mesh.material.side !== THREE.BackSide){
-          mesh.material.side = THREE.BackSide
-        }else{
-          mesh.material.side = 0
-        }*/
-        mesh.material.side = THREE.BackSide
-      }
+      const inversions = flipped.reduce((prev, curr) => prev + curr)
+      mesh.material.side = isOdd(inversions) ? THREE.BackSide : 0
     }
-
-    foo()
-
-    /*if(transform.sca[0] <0 && (!mesh.flipped || ( mesh.flipped && !mesh.flipped[0])) ){
-      //mesh.scale.x = Math.abs(mesh.scale.x)
-      let mS = (new THREE.Matrix4()).identity()
-      const conv =[0, 5, 10]
-      mS.elements[conv[0]] = -1
-      //set -1 to the corresponding axis
-      mesh.geometry.applyMatrix(mS)
-
-      //only do this once ?
-      if(mesh.material.side != THREE.BackSide)
-      {
-        mesh.material.side = THREE.BackSide
-      }
-
-      if(!mesh.flipped){
-        mesh.flipped = [1,0,0]
-      }
-    }*/
-
-    /*if(transform.sca[1] <0 && (!mesh.flipped || ( mesh.flipped && !mesh.flipped[1])) ){
-      //mesh.scale.x = Math.abs(mesh.scale.x)
-      let mS = (new THREE.Matrix4()).identity()
-      const conv =[0, 5, 10]
-      mS.elements[conv[1]] = -1
-      mS.elements[conv[0]] = -1
-      mS.elements[conv[2]] = -1
-      //set -1 to the corresponding axis
-      mesh.geometry.applyMatrix(mS)
-
-      //only do this once ?
-      if(mesh.material.side != THREE.BackSide)
-      {
-        //mesh.material.side = THREE.BackSide
-      }
-      if(!mesh.flipped){
-        mesh.flipped = [0,1,0]
-      }
-    }*/
-
+    handleMirroring()
 
     return setFlags(mesh)
   }

--- a/src/components/webgl/model.js
+++ b/src/components/webgl/model.js
@@ -2,6 +2,7 @@ import { exists, combineLatestObj } from '../../utils/obsUtils'
 import { equals } from 'ramda'
 
 import { makeNoteVisual, makeDistanceVisual, makeThicknessVisual, makeDiameterVisual, makeAngleVisual } from './visualMakers'
+import THREE from 'three'
 
 // let requestAnimationFrameScheduler = Rx.Scheduler.requestAnimationFrame
 // problem : this fires BEFORE the rest is ready
@@ -27,10 +28,33 @@ function makeRemoteMeshVisual (meta, transform, mesh) {
       mesh.rotation.fromArray(transform.rot)
     }
     if (!equals(mesh.scale.toArray(), transform.sca)) {
-      mesh.scale.fromArray(transform.sca)
+      mesh.scale.fromArray(transform.sca.map(Math.abs))
     }
     // color is stored in meta component
     mesh.material.color.set(meta.color)
+
+    //this is for mirroring
+    if(transform.sca[0] >0 && mesh.flipped && mesh.material.side === THREE.BackSide){
+      let mS = (new THREE.Matrix4()).identity()
+      const conv =[0, 5, 10]
+      mS.elements[conv[0]] = -1
+      mesh.geometry.applyMatrix(mS)
+      mesh.material.side = 0
+      mesh.flipped = false
+    }
+    if(transform.sca[0] <0 && !mesh.flipped){
+      //mesh.scale.x = Math.abs(mesh.scale.x)
+      let mS = (new THREE.Matrix4()).identity()
+      const conv =[0, 5, 10]
+      //set -1 to the corresponding axis
+      mS.elements[conv[0]] = -1
+
+      mesh.geometry.applyMatrix(mS)
+      mesh.material.side = THREE.BackSide
+      mesh.flipped = true
+    }
+
+
     return setFlags(mesh)
   }
 }

--- a/src/components/webgl/model.js
+++ b/src/components/webgl/model.js
@@ -33,26 +33,144 @@ function makeRemoteMeshVisual (meta, transform, mesh) {
     // color is stored in meta component
     mesh.material.color.set(meta.color)
 
+
+    console.log('transforms scale',transform.sca)
+    function mirroredAxis(t){
+      return t
+        .map(val => (val >= 0)? 0: 1 )
+    }
+    const mirrored = t =>t.map(val => val <0).reduce( (prev, curr) => prev || curr )
+
+    function isOdd(num) { return num % 2}
+
     //this is for mirroring
-    if(transform.sca[0] >0 && mesh.flipped && mesh.material.side === THREE.BackSide){
-      let mS = (new THREE.Matrix4()).identity()
+    if(!mirrored(transform.sca) && mesh.flipped && mesh.material.side === THREE.BackSide){
+      //reset mirroring
+      /*let mS = (new THREE.Matrix4()).identity()
       const conv =[0, 5, 10]
       mS.elements[conv[0]] = -1
       mesh.geometry.applyMatrix(mS)
       mesh.material.side = 0
-      mesh.flipped = false
+      mesh.flipped = false*/
     }
-    if(transform.sca[0] <0 && !mesh.flipped){
+    console.log('mirrored',mirrored(transform.sca))
+    /*if(mirrored(transform.sca) ){
+
+      const flipped = mesh.flipped || [0,0,0]
+
+      let mS = (new THREE.Matrix4()).identity()
+      let inversions = 0
+
+
+      const conv =[0, 5, 10]
+      transform.sca
+        .map(val => val <0)
+        .forEach(function(val, index){
+          if(val && flipped[index]===0){
+            console.log('val',val, index)
+            mS.elements[conv[index]] = -1
+            inversions += 1
+          }
+        })
+      //set -1 to the corresponding axis
+      mesh.geometry.applyMatrix(mS)
+
+      console.log('inversions', inversions, 'mirroredAxis', mirroredAxis(transform.sca))
+      if(mesh.material.side != THREE.BackSide && (inversions === 1 || inversions ==3) )
+      {
+        console.log('flipping material')
+        mesh.material.side = THREE.BackSide
+      }
+
+      mesh.flipped = mirroredAxis(transform.sca)
+    }*/
+
+
+    function foo(){
+      let flipped = mesh.flipped || [0,0,0]
+
+      let mS = (new THREE.Matrix4()).identity()
+      let inversions = 0
+
+
+      const conv =[0, 5, 10]
+      transform.sca
+        .map(val => val <0)
+        .forEach(function(val, index){
+          if(val && flipped[index]===0){
+            mS.elements[conv[index]] = -1
+            inversions += 1
+            flipped[index]=1
+          }
+          //flip back
+          if(!val && flipped[index]===1){
+            mS.elements[conv[index]] = -1
+            inversions += 1
+            flipped[index] = 0
+          }
+        })
+      mesh.geometry.applyMatrix(mS)
+      mesh.flipped = flipped
+      inversions = flipped.reduce( (prev, curr) => prev || curr )
+
+      console.log('inversions', inversions ,flipped)
+      if(!isOdd(inversions)){
+        /*if(mesh.material.side !== THREE.BackSide){
+          mesh.material.side = THREE.BackSide
+        }else{
+          mesh.material.side = 0
+        }*/
+        mesh.material.side = 0
+      }else{
+        /*if(mesh.material.side !== THREE.BackSide){
+          mesh.material.side = THREE.BackSide
+        }else{
+          mesh.material.side = 0
+        }*/
+        mesh.material.side = THREE.BackSide
+      }
+    }
+
+    foo()
+
+    /*if(transform.sca[0] <0 && (!mesh.flipped || ( mesh.flipped && !mesh.flipped[0])) ){
       //mesh.scale.x = Math.abs(mesh.scale.x)
       let mS = (new THREE.Matrix4()).identity()
       const conv =[0, 5, 10]
-      //set -1 to the corresponding axis
       mS.elements[conv[0]] = -1
-
+      //set -1 to the corresponding axis
       mesh.geometry.applyMatrix(mS)
-      mesh.material.side = THREE.BackSide
-      mesh.flipped = true
-    }
+
+      //only do this once ?
+      if(mesh.material.side != THREE.BackSide)
+      {
+        mesh.material.side = THREE.BackSide
+      }
+
+      if(!mesh.flipped){
+        mesh.flipped = [1,0,0]
+      }
+    }*/
+
+    /*if(transform.sca[1] <0 && (!mesh.flipped || ( mesh.flipped && !mesh.flipped[1])) ){
+      //mesh.scale.x = Math.abs(mesh.scale.x)
+      let mS = (new THREE.Matrix4()).identity()
+      const conv =[0, 5, 10]
+      mS.elements[conv[1]] = -1
+      mS.elements[conv[0]] = -1
+      mS.elements[conv[2]] = -1
+      //set -1 to the corresponding axis
+      mesh.geometry.applyMatrix(mS)
+
+      //only do this once ?
+      if(mesh.material.side != THREE.BackSide)
+      {
+        //mesh.material.side = THREE.BackSide
+      }
+      if(!mesh.flipped){
+        mesh.flipped = [0,1,0]
+      }
+    }*/
 
 
     return setFlags(mesh)

--- a/src/core/entities/components/mesh.js
+++ b/src/core/entities/components/mesh.js
@@ -37,16 +37,15 @@ export function makeMeshSystem (actions) {
       let original = {}
       original = state[input.id]
 
-
-      let mesh = original.clone()// meh ?//FIXME : make sure there are no multiple clones
-      mesh.material = mesh.material.clone() // {mesh: inputValue.mesh }// mergeData(defaults,inputValue)
       let id = input.id
+      let mesh = original/*original.clone()// meh ?//FIXME : make sure there are no multiple clones
+      mesh.material = mesh.material.clone() // {mesh: inputValue.mesh }// mergeData(defaults,inputValue)
+
 
       mesh.userData.entity = {id}
-      mesh.pickable = true
+      mesh.pickable = true*/
 
-      //mesh.scale(-1, 1, 1)
-      let mS = (new THREE.Matrix4()).identity()
+      /*let mS = (new THREE.Matrix4()).identity()
 
       const conv =[0, 5, 10]
       //set -1 to the corresponding axis
@@ -55,21 +54,21 @@ export function makeMeshSystem (actions) {
       //mS.elements[5] = -1; // y
       //mS.elements[10] = -1 // z
 
-      //mesh.geometry.applyMatrix(mS)
+      mesh.geometry.applyMatrix(mS)
       //flip things
-      /*mesh.geometry.dynamic = true
+      mesh.geometry.dynamic = true
       mesh.geometry.attributes.position.needsUpdate = true
 
       var p = mesh.geometry.attributes.normal.array
       for(var i =0; i<p.length; i++){
         p[i] = -p[i]
-      }*/
+      }
       if (mesh.material.side === 0) {
         mesh.material.side = THREE.BackSide
       }
       else {
         mesh.material.side = 0
-      }
+      }*/
 
       console.log('mirrorComponents', state, input)
 

--- a/src/core/entities/components/mesh.js
+++ b/src/core/entities/components/mesh.js
@@ -55,15 +55,15 @@ export function makeMeshSystem (actions) {
       //mS.elements[5] = -1; // y
       //mS.elements[10] = -1 // z
 
-      mesh.geometry.applyMatrix(mS)
+      //mesh.geometry.applyMatrix(mS)
       //flip things
-      mesh.geometry.dynamic = true
+      /*mesh.geometry.dynamic = true
       mesh.geometry.attributes.position.needsUpdate = true
 
       var p = mesh.geometry.attributes.normal.array
       for(var i =0; i<p.length; i++){
         p[i] = -p[i]
-      }
+      }*/
       if (mesh.material.side === 0) {
         mesh.material.side = THREE.BackSide
       }

--- a/src/core/entities/components/mesh.js
+++ b/src/core/entities/components/mesh.js
@@ -32,58 +32,10 @@ export function makeMeshSystem (actions) {
     }, state)
   }
 
-  function mirrorComponents (defaults, state, inputs) {
-    return inputs.reduce(function (state, input) {
-      let original = {}
-      original = state[input.id]
-
-      let id = input.id
-      let mesh = original/*original.clone()// meh ?//FIXME : make sure there are no multiple clones
-      mesh.material = mesh.material.clone() // {mesh: inputValue.mesh }// mergeData(defaults,inputValue)
-
-
-      mesh.userData.entity = {id}
-      mesh.pickable = true*/
-
-      /*let mS = (new THREE.Matrix4()).identity()
-
-      const conv =[0, 5, 10]
-      //set -1 to the corresponding axis
-      mS.elements[conv[input.axis]] = -1
-      //mS.elements[0] = -1 // x
-      //mS.elements[5] = -1; // y
-      //mS.elements[10] = -1 // z
-
-      mesh.geometry.applyMatrix(mS)
-      //flip things
-      mesh.geometry.dynamic = true
-      mesh.geometry.attributes.position.needsUpdate = true
-
-      var p = mesh.geometry.attributes.normal.array
-      for(var i =0; i<p.length; i++){
-        p[i] = -p[i]
-      }
-      if (mesh.material.side === 0) {
-        mesh.material.side = THREE.BackSide
-      }
-      else {
-        mesh.material.side = 0
-      }*/
-
-      console.log('mirrorComponents', state, input)
-
-      state = mergeData({}, state)
-      state[id] = mesh
-      // FIXME big hack, use immutability !!!
-
-      return state
-    }, state)
-  }
 
   // TODO: should defaults be something like a stand in cube ?
   let updateFns = {
     createComponents: createComponentsMesh.bind(null, undefined),
-    mirrorComponents: mirrorComponents.bind(null, undefined),
     duplicateComponents,
     removeComponents
   }

--- a/src/core/entities/components/transforms.js
+++ b/src/core/entities/components/transforms.js
@@ -1,6 +1,5 @@
 import { createComponents, removeComponents, duplicateComponents, makeActionsFromApiFns } from './common'
 import { makeModel, mergeData } from '../../../utils/modelUtils'
-
 // //Transforms//////
 
 export function makeTransformsSystem (actions) {

--- a/src/core/entities/components/transforms.js
+++ b/src/core/entities/components/transforms.js
@@ -48,6 +48,28 @@ export function makeTransformsSystem (actions) {
     return state
   }
 
+  function mirrorComponents (state, inputs) {
+    console.log('mirroring transforms', inputs)
+
+    return inputs.reduce(function (state, input) {
+      console.log('mirrorComponents (transforms)')
+      let {id} = input
+
+      let sca  = state[id].sca
+      //const conv =[1, 1, 1]
+      //set -1 to the corresponding axis
+      sca[input.axis] *= -1
+
+      //let sca = input.value || [1, 1, Math.random()]
+      let orig = state[id] || transformDefaults
+
+      state = mergeData({}, state)
+      // FIXME big hack, use mutability
+      state[id] = mergeData({}, orig, {sca})
+      return state
+    }, state)
+  }
+
   function updateComponents (state, inputs) {
     console.log('updating transforms', inputs)
 
@@ -67,6 +89,7 @@ export function makeTransformsSystem (actions) {
     updateRotation,
     updatePosition,
     updateScale,
+    mirrorComponents,
     updateComponents,
     createComponents: createComponents.bind(null, transformDefaults),
     duplicateComponents,

--- a/src/core/entities/components/transforms.js
+++ b/src/core/entities/components/transforms.js
@@ -53,16 +53,15 @@ export function makeTransformsSystem (actions) {
     return inputs.reduce(function (state, input) {
       let {id} = input
 
-      let sca  = state[id].sca
-      //set -1 to the corresponding axis
+      let sca = state[id].sca.map(d=>d)// DO NOT REMOVE ! a lot of code relies on diffing, and if you mutate the original scale, it breaks !
       sca[input.axis] *= -1
 
-      //let sca = input.value || [1, 1, Math.random()]
       let orig = state[id] || transformDefaults
 
       state = mergeData({}, state)
       // FIXME big hack, use mutability
       state[id] = mergeData({}, orig, {sca})
+
       return state
     }, state)
   }

--- a/src/core/entities/components/transforms.js
+++ b/src/core/entities/components/transforms.js
@@ -51,11 +51,9 @@ export function makeTransformsSystem (actions) {
     console.log('mirroring transforms', inputs)
 
     return inputs.reduce(function (state, input) {
-      console.log('mirrorComponents (transforms)')
       let {id} = input
 
       let sca  = state[id].sca
-      //const conv =[1, 1, 1]
       //set -1 to the corresponding axis
       sca[input.axis] *= -1
 

--- a/src/core/entities/utils.js
+++ b/src/core/entities/utils.js
@@ -144,6 +144,7 @@ export function remapTransformActions (entityActions, componentBase$, currentSel
   return {
     createComponents$,
     updateComponents$,
+    mirrorComponents$: entityActions.mirrorInstances$,
     duplicateComponents$,
     removeComponents$,
     clearDesign$: entityActions.clearDesign$

--- a/src/core/entities/utils.js
+++ b/src/core/entities/utils.js
@@ -105,11 +105,8 @@ export function remapMeshActions (entityActions, componentBase$, currentSelectio
   const removeComponents$ = entityActions.deleteInstances$
   const duplicateComponents$ = entityActions.duplicateInstances$
 
-  entityActions.mirrorInstances$.forEach(e=> console.log('mirrorInstances',e))
-
   return {
     createComponents$,
-    mirrorComponents$: entityActions.mirrorInstances$,
     duplicateComponents$,
     removeComponents$,
     clearDesign$: entityActions.clearDesign$


### PR DESCRIPTION
This PR fixes the behaviour of the mirror tool:

- mirroring state is now saved (negative scale)
- no more need to updated geometry (normals) so much faster

Check:

- [x] does any combo of mirroring axis result in weird (visually) results ?
- [x] does any combo of mirroring axis result in unselectable meshes?
- [x] is the mirroring 'state' saved & reloaded correctly
- [x] disable other tool 'gizmos' when switching to mirror (ie disable the 3d uis for translate, rotate, scale etc)

