### PR TITLE
constrain sizing + snap scaling + snap rotation

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1244,8 +1244,13 @@ Chrome, Safari, Opera */
   padding: 10px
 }
 
-.label{
+.popOverContent{
+  display: block;
+  float: left;
+  margin: 2px 10px;
+  clear: both;
   font-size: 1.1em;
+  cursor: pointer;
 }
 
 /* Base styles for the element that has a tooltip */

--- a/src/components/EntityInfos/index.js
+++ b/src/components/EntityInfos/index.js
@@ -31,8 +31,9 @@ function model (props$, actions) {
   let comments$ = props$.pluck('comments').filter(exists).startWith(undefined)
   let meta$ = props$.pluck('meta').filter(exists).startWith(undefined)
   let transforms$ = props$.pluck('transforms').filter(exists).startWith(undefined)
+  let settings$ = props$.pluck('settings').filter(exists).startWith(undefined)
 
-  return combineLatestObj({meta$, transforms$, comments$})
+  return combineLatestObj({meta$, transforms$, comments$, settings$})
     .distinctUntilChanged()
     .shareReplay(1)
 }

--- a/src/components/EntityInfos/view.js
+++ b/src/components/EntityInfos/view.js
@@ -8,6 +8,11 @@ import { isEmpty } from '../../utils/utils'
 // //////
 import ColorPicker from '../widgets/ColorPicker'
 
+const snapDefaults = {
+  rot: 10, // snap rotation snaps to tens of degrees
+  sca: 0.1 // snap scaling snaps to tens of percentages
+}
+
 export function colorPickerWrapper (state$, DOM) {
   const props$ = just({color: '#FF00FF'})
 
@@ -175,13 +180,36 @@ function transformInputs (transforms, fieldName, displayName, controlsStep, numb
   }
 }
 
+function getControlStep (transformType) {//, snapping) {
+  let snapping = true // please replace this with actual settings
+  switch (transformType) {
+    case 'pos':
+      return 0.1
+    case 'rot':
+      if (snapping) {
+        return snapDefaults.rot
+      } else {
+        return 0.5
+      }
+      break
+    case 'sca':
+      if (snapping) {
+        return snapDefaults.sca
+      } else {
+        return 0.01
+      }
+      break
+    default:
+      return 0.4
+  }
+}
+
 export default function view (state$, colorPicker) {
   let numberPrecision = 2
-  let controlsStep = 0.5
 
   // {colorPicker}
   return state$.map(function (state) {
-    let {meta, transforms} = state
+    let {meta, transforms, settings} = state
 
     if (!meta || !transforms) {
       return undefined
@@ -194,9 +222,9 @@ export default function view (state$, colorPicker) {
     return <div className='toolBarBottom entityInfos'>
              {colorInput(meta)}
              {nameInput(meta)}
-             {transformInputs(transforms, 'pos', undefined, controlsStep, numberPrecision)}
-             {transformInputs(transforms, 'rot', undefined, controlsStep, numberPrecision)}
-             {transformInputs(transforms, 'sca', undefined, controlsStep, numberPrecision)}
+             {transformInputs(transforms, 'pos', undefined, getControlStep('pos'), numberPrecision)}
+             {transformInputs(transforms, 'rot', undefined, getControlStep('rot'), numberPrecision)}
+             {transformInputs(transforms, 'sca', undefined, getControlStep('sca'), numberPrecision)}
            </div>
   })
 }

--- a/src/components/main/model.js
+++ b/src/components/main/model.js
@@ -53,7 +53,7 @@ export default function model (props$, actions, sources) {
 
   const metaActions = remapMetaActions(entityActions, componentBase$, proxySelections$, addAnnotations$)
   const meshActions = remapMeshActions(entityActions, componentBase$, proxySelections$)
-  const transformActions = remapTransformActions(entityActions, componentBase$, proxySelections$)
+  const transformActions = remapTransformActions(entityActions, componentBase$, proxySelections$, settings$)
   const boundActions = remapBoundsActions(entityActions, componentBase$, proxySelections$)
 
   const {meta$} = makeMetaSystem(metaActions)

--- a/src/components/main/view.js
+++ b/src/components/main/view.js
@@ -202,17 +202,22 @@ function makeTopToolBar(state){
 
     function getPopOverContent (popOverType) {
       switch (popOverType) {
-        case 'snapScaling':
-          return undefined
+        case 'scalingSubTools':
+          // return undefined
           return <span>
-            <input type='checkbox' className={Class('checkbox', popOverType)} checked='checked' />
-            <label className={Class('label', popOverType)}>Snap scaling</label>
+            <label className='popOverContent'>
+              <input type='checkbox' className='snapScaling' checked={state.settings.snapScaling}/>snap scaling
+            </label>
+            <label className='popOverContent'>
+              <input type='checkbox' className='uniformScaling' checked={state.settings.uniformScaling}/>uniform scaling
+            </label>
           </span>
-        case 'snapRotation':
-          return undefined
+        case 'rotationSubTools':
+          // return undefined
           return <span>
-            <input type='checkbox' className={Class('checkbox', popOverType)} checked='checked' />
-            <label className={Class('label', popOverType)}> Snap rotation</label>
+            <label className='popOverContent'>
+              <input type='checkbox' className='snapRotation' checked={state.settings.snapRotation}/>snap rotation
+            </label>
           </span>
         case 'mirrorSubTools':
           return <span>
@@ -231,10 +236,10 @@ function makeTopToolBar(state){
         , translateIconSvg, "toTranslateMode", "move", "bottom")}
 
       {tooltipIconBtn(rotateModeToggled
-        , rotateIconSvg, "toRotateMode", "rotate", "bottom", false, getPopOverContent('snapRotation'))}
+        , rotateIconSvg, "toRotateMode", "rotate", "bottom", false, getPopOverContent('rotationSubTools'))}
 
       {tooltipIconBtn(scaleModeToggled
-        , scaleIconSvg, "toScaleMode", "scale", "bottom", false,  getPopOverContent('snapScaling'))}
+        , scaleIconSvg, "toScaleMode", "scale", "bottom", false,  getPopOverContent('scalingSubTools'))}
 
       {tooltipIconBtn(mirrorModeToggled
         , mirrorIconSvg, "toMirrorMode", "mirror", "bottom", false, getPopOverContent('mirrorSubTools'))}

--- a/src/core/entities/utils.js
+++ b/src/core/entities/utils.js
@@ -114,7 +114,7 @@ export function remapMeshActions (entityActions, componentBase$, currentSelectio
 }
 
 // function to add extra data to transform component actions
-export function remapTransformActions (entityActions, componentBase$, currentSelections$) {
+export function remapTransformActions (entityActions, componentBase$, currentSelections$, settings$) {
   const createComponents$ = componentBase$
     .filter(c => c.length > 0)
     .map(function (datas) {
@@ -130,9 +130,9 @@ export function remapTransformActions (entityActions, componentBase$, currentSel
   const updateComponents$ = entityActions.updateComponent$
     .filter(u => u.target === 'transforms')
     .pluck('data')
-    .withLatestFrom(currentSelections$.map(s => s.map(s => s.id)), function (transforms, instIds) {
+    .withLatestFrom(currentSelections$.map(s => s.map(s => s.id)),settings$, function (transforms, instIds, settings) {
       return instIds.map(function (instId) {
-        return {id: instId, value: transforms}
+        return {id: instId, value: transforms, settings}
       })
     })
 

--- a/src/core/settings/actions/fromDOM.js
+++ b/src/core/settings/actions/fromDOM.js
@@ -16,6 +16,10 @@ export default function intent (DOM, params) {
   const toggleAutoRotate$ = DOM.select('.settingsView .autoRotate').events('change').map(checked)
   const toggleFullScreen$ = DOM.select('.fullScreenToggler').events('click')
 
+  const toggleSnapScaling$ = DOM.select('.popOverContent .snapScaling').events('change').map(checked)
+  const toggleUniformScaling$ = DOM.select('.popOverContent .uniformScaling').events('change').map(checked)
+  const toggleSnapRotation$ = DOM.select('.popOverContent .snapRotation').events('change').map(checked)
+
   // const toggleAutoSelectNewEntities$ = Rx.Observable.just(true) //TODO: make settable
   // tools
   // const toggleRepeatTool$            = Rx.Observable.just(false) // does a tool gets stopped after a single use or not
@@ -53,6 +57,9 @@ export default function intent (DOM, params) {
     setActiveTool$,
     toggleAutoRotate$,
     toggleShowGrid$,
-    toggleShowAnnot$
+    toggleShowAnnot$,
+    toggleSnapScaling$,
+    toggleUniformScaling$,
+    toggleSnapRotation$
   }
 }

--- a/src/core/settings/settings.js
+++ b/src/core/settings/settings.js
@@ -47,6 +47,24 @@ function toggleAutoRotate (state, input) {
   return output
 }
 
+function toggleSnapScaling (state, input) {
+  console.log('toggleSnapScaling', input)
+  let output = mergeData(state, {snapScaling: input})
+  return output
+}
+
+function toggleUniformScaling (state, input) {
+  console.log('toggleUniformScaling', input)
+  let output = mergeData(state, {uniformScaling: input})
+  return output
+}
+
+function toggleSnapRotation (state, input) {
+  console.log('toggleSnapRotation', input)
+  let output = mergeData(state, {snapRotation: input})
+  return output
+}
+
 function setActiveTool (state, input) {
   console.log('setting activeTool', input)
   let output = mergeData(state, {activeTool: input})
@@ -97,7 +115,7 @@ function settings (actions, source) {
 
     toolSets: ['view', 'edit', 'annotate'], // what categories of tools do we want on screen
 
-    selections: undefined, //FIXME : not entirely sure this should even be here
+    selections: undefined, // FIXME : not entirely sure this should even be here
 
     // these are "domain specific", there should be a way for sub systems
     // to "hook up" to the main data storage
@@ -113,14 +131,20 @@ function settings (actions, source) {
       show: true
     },
 
-    //persistence
+    // persistence
     autoSave: false,
-    autoLoad: true
+    autoLoad: true,
+
+    snapScaling: true,
+    uniformScaling: true,
+    snapRotation: true
   }
 
-  let updateFns = {setAllValues, toggleShowGrid,
-    toggleAutoRotate, setActiveTool, setAppMode, setToolsets,
-    setAutoSave, setAutoLoad}
+  const test = 'test'
+
+  let updateFns = {setAllValues, toggleShowGrid, toggleAutoRotate,
+    toggleSnapScaling, toggleUniformScaling, toggleSnapRotation,
+    setActiveTool, setAppMode, setToolsets, setAutoSave, setAutoLoad}
   return makeModel(defaults, updateFns, actions, source)
 }
 


### PR DESCRIPTION
This are the functionalities for: contrain sizing + snap scaling + snap rotation

## some extra info on the side
- In the fourth commit you can see a lot of code that would apply constrain sizing in respect to the sizing that was already done by the user (instead of reverting the model to its old dimensions). This code did work but went completely belly-up when you would shake the mouse within the move. So I went back to the code I already had.
- I chose to have the input field abide by the settings, because I saw designs for the future in which the input fields will be in the popdown, and therefore will be visually 'paired'. 
- The input fields in the bottom abide by the constrain sizing and snapping, but do not visually do so and the step size is also not adapted to the settings. So I'm going to spent the time I have left working on this. 

## How to test
- load a model and just start sizing. In all steps don't just resize, but give it hell, shake your mouse everywhere and make moves within moves. 
- See whether the sizing abides by the settings as selected (snap rotation, snap scaling and uniform scaling
- Also test the combination of transformations, especially mirror -> scale and scale -> mirror.
- Also combine the combination of transformation using the input fields in the bottom and the gizmo (manual input). See whether the input fields also abide by snap scaling, snap rotation and uniform scaling. 