### PR TITLE
Zoom in on all instances from the BOM

### DIFF
--- a/src/components/Bom/index.js
+++ b/src/components/Bom/index.js
@@ -7,13 +7,14 @@ export default function Bom ({DOM, props$}) {
   const state$ = model(props$, actions)
   const vtree$ = view(state$)
 
-  // FIXME: stopgap solution
+  // FIXME: stopgap solution : do not understand this issue, these actions should be hot & shared
   actions.removeEntry$.forEach(e => e)
 
   return {
     DOM: vtree$,
     events: {
       entryTapped$: actions.entryTapped$,
+      entryDoubleTapped$: actions.entryDoubleTapped$,
       editEntry$: actions.editEntry$,
       addEntry$: actions.addEntry$,
       removeEntry$: actions.removeEntry$

--- a/src/components/main/wrappers.js
+++ b/src/components/main/wrappers.js
@@ -111,17 +111,21 @@ export function GLWrapper (state$, drivers) {
 
   const selections$ = selectedInstIds$
     .withLatestFrom(state$, function (ids, state) {
-      // console.log("gnagna gna")
-      let meta = ids.map(function (id) {
+      return ids.map(function (id) {
         return state.meta[id]
       })
-      return meta
     })
     .shareReplay(1)
+
+  const focusedEntities$ = state$
+    .pluck('selections')
+    .map(s => s.focusInstIds)
+    .filter(s => s !== undefined)
 
   let glProps$ = combineLatestObj({
     settings: state$.pluck('settings'),
     selections$,
+    focusedEntities$,
     meta: state$.pluck('meta'),
     meshes: state$.pluck('meshes'),
     transforms: state$.pluck('transforms'),

--- a/src/components/webgl/GlView.js
+++ b/src/components/webgl/GlView.js
@@ -29,9 +29,9 @@ let ShadowPlane = planes.ShadowPlane.default // ugh FIXME: bloody babel6
 let {zoomInOn, zoomToFit} = cameraEffects
 
 import zoomToFitBounds from './cameraUtils2'
-import {computeBoundingBox} from './computeBounds2'
+import { computeBoundingBox } from './computeBounds2'
 
-import { makeCamera, makeControls, makeLight, renderMeta} from './utils2'
+import { makeCamera, makeControls, makeLight, renderMeta } from './utils2'
 
 import { presets } from './presets' // default configuration for lighting, cameras etc
 
@@ -126,7 +126,7 @@ function setupPostProcess (camera, renderer, scene) {
 
   return {composers: [composer], fxaaPass, outScene, maskScene}
 
-  // return {composer:finalComposer, fxaaPass, outScene, maskScene, composers:[normalComposer,depthComposer,finalComposer]}
+// return {composer:finalComposer, fxaaPass, outScene, maskScene, composers:[normalComposer,depthComposer,finalComposer]}
 }
 
 import intent from './intent'
@@ -204,17 +204,11 @@ function GLView ({drivers, props$}) {
     .forEach((oAndP) => zoomInOn(oAndP.object, camera, {position: oAndP.point}))
 
   zoomToFit$
-    .tap(e=>console.info('zoomToFit', e))
-    .map(function(meshesToFocus){
+    .map(function (meshesToFocus) {
       let wrapperObject = new THREE.Object3D()
       wrapperObject.boundingBox = computeBoundingBox(wrapperObject, meshesToFocus)
       wrapperObject.boundingSphere = wrapperObject.boundingBox.getBoundingSphere()
-      console.log('wrapperObject', wrapperObject)
-
-      const centerX = 0.5 * ( wrapperObject.boundingBox.max.x - wrapperObject.boundingBox.min.x )
-      const centerY = 0.5 * ( wrapperObject.boundingBox.max.y - wrapperObject.boundingBox.min.y )
-      const centerZ = 0.5 * ( wrapperObject.boundingBox.max.z - wrapperObject.boundingBox.min.z )
-      const center = new THREE.Vector3(centerX, centerY, centerZ)
+      const center = new THREE.Vector3().subVectors(wrapperObject.boundingBox.max, wrapperObject.boundingBox.min).multiplyScalar(0.5)
       return {focusMesh: wrapperObject, center}
     })
     .forEach(({focusMesh, center}) => zoomToFitBounds(focusMesh, camera, center))
@@ -391,8 +385,7 @@ function GLView ({drivers, props$}) {
           transformControls.attach(mesh)
           transformControls.setMode(tool)
         }
-        else if ((!tool && mesh) || ['translate', 'rotate', 'scale'].indexOf(tool) === -1)
-        { // tool is undefined, but we still had selections
+        else if ((!tool && mesh) || ['translate', 'rotate', 'scale'].indexOf(tool) === -1) { // tool is undefined, but we still had selections
           transformControls.detach(mesh)
         }
       })

--- a/src/components/webgl/cameraUtils2.js
+++ b/src/components/webgl/cameraUtils2.js
@@ -1,0 +1,82 @@
+import THREE from 'three'
+
+export default function zoomToFitBounds (object, camera, target) {
+  let bbox = object.boundingBox
+  if (bbox.empty()) {
+    return
+  }
+  let COG = bbox.center()
+
+  //pointCameraTo(COG, target, camera)
+  //camera.lookAt(COG)
+
+  /*let sphereSize = object.boundingSphere.radius // bbox.size().length() * 0.5
+  let distToCenter = sphereSize / Math.sin(Math.PI / 180.0 * camera.fov * 0.5)
+*/
+  // move the camera backward
+
+  console.log('bbbox',bbox.center())
+  target = bbox.center()
+  //let vec = new THREE.Vector3()
+  // compute vector from cam position to target
+  //vec.subVectors(camera.position, target)
+  // set that vector's length to the distance to the center
+  //vec.setLength(distToCenter)
+  // offset camera position by offset distance + target
+  //camera.position.addVectors(vec , target)
+
+  const height = 100
+
+  const correctForDepth = 1.7
+  const radius =  object.boundingSphere.radius
+  const center =  object.boundingSphere.center
+  const distance = height / 2 / Math.tan(Math.PI * fov / 360)//center.distanceTo(camera.position) - radius
+  const offset = new THREE.Vector3().subVectors(center, camera.position)
+
+
+  var realHeight = Math.abs(bbox.max.y - bbox.min.y)
+  var fov = 2 * Math.atan(realHeight * correctForDepth / ( 2 * distance )) * ( 180 / Math.PI )
+  //camera.fov = fov
+
+  //move camera
+  console.log('offset',offset)
+  //console.log('camera',camera.target, camera.position, camera)
+  camera.position.add(offset)
+  //camera.target.copy(target)
+
+  camera.updateProjectionMatrix()
+  camera.toPerspective()
+
+// possible api change, to have function return data instead of mutating anything
+/*vec.addVectors(vec, target)
+
+return {COG,offset:vec}
+
+//in other function ??
+pointCameraTo(COG, target, camera)
+camera.lookAt(COG)*/
+}
+
+/**
+ * point the current camera to the center
+ * of the graphical object (zoom factor is not affected)
+ *
+ * the camera is moved in its  x,z plane so that the orientation
+ * is not affected either
+ */
+export function pointCameraTo (COG, target, camera) {
+  // Refocus camera to the center of the new object
+  let v = new THREE.Vector3()
+  v.subVectors(COG, target)
+
+  camera.position.addVectors(camera.position, v)
+}
+
+// non mutating
+export function positionOfCameraPointedTo (COG, target, camera) {
+  // Refocus camera to the center of the new object
+  let v = new THREE.Vector3()
+  v.subVectors(COG, target)
+
+  return camera.position.clone().addVectors(camera.position, v)
+}

--- a/src/components/webgl/cameraUtils2.js
+++ b/src/components/webgl/cameraUtils2.js
@@ -7,42 +7,56 @@ export default function zoomToFitBounds (object, camera, target) {
   }
   let COG = bbox.center()
 
-  //pointCameraTo(COG, target, camera)
-  //camera.lookAt(COG)
+  // pointCameraTo(COG, target, camera)
+  // camera.lookAt(COG)
 
   /*let sphereSize = object.boundingSphere.radius // bbox.size().length() * 0.5
   let distToCenter = sphereSize / Math.sin(Math.PI / 180.0 * camera.fov * 0.5)
 */
   // move the camera backward
 
-  console.log('bbbox',bbox.center())
+  console.log('bbbox', bbox.center())
   target = bbox.center()
-  //let vec = new THREE.Vector3()
+  // let vec = new THREE.Vector3()
   // compute vector from cam position to target
-  //vec.subVectors(camera.position, target)
+  // vec.subVectors(camera.position, target)
   // set that vector's length to the distance to the center
-  //vec.setLength(distToCenter)
+  // vec.setLength(distToCenter)
   // offset camera position by offset distance + target
-  //camera.position.addVectors(vec , target)
+  // camera.position.addVectors(vec , target)
 
   const height = 100
 
   const correctForDepth = 1.7
-  const radius =  object.boundingSphere.radius
-  const center =  object.boundingSphere.center
-  const distance = height / 2 / Math.tan(Math.PI * fov / 360)//center.distanceTo(camera.position) - radius
-  const offset = new THREE.Vector3().subVectors(center, camera.position)
+  const radius = object.boundingSphere.radius
+  const center = object.boundingSphere.center
   const targetOffset = new THREE.Vector3().subVectors(center, camera.target)
 
-
   var realHeight = Math.abs(bbox.max.y - bbox.min.y)
-  var fov = 2 * Math.atan(realHeight * correctForDepth / ( 2 * distance )) * ( 180 / Math.PI )
-  //camera.fov = fov
+  //  const distance = height / 2 / Math.tan(Math.PI * fov / 360)// center.distanceTo(camera.position) - radius
 
-  //move camera
-  console.log('offset',targetOffset)
+  // var fov = 2 * Math.atan(realHeight * correctForDepth / ( 2 * distance )) * ( 180 / Math.PI )
+  // camera.fov = fov
+
+  var fov = camera.fov * (Math.PI / 180)
+  // Calculate the camera distance
+  var distance = Math.abs(realHeight / Math.sin(fov / 2))
+
+  //var maxDim = Math.max(w, h)
+  //var aspectRatio = w / h
+  //var distance = maxDim / 2 / aspectRatio / Math.tan(Math.PI * fov / 360)
+
+  // move camera
+  console.log('offset', targetOffset)
   camera.position.add(targetOffset)
   camera.target.copy(center)
+
+  let vec = new THREE.Vector3()
+  vec.subVectors(camera.position, camera.target)
+  vec.normalize()
+  vec.setLength(center.distanceTo(camera.position) - radius*4)
+  console.log('distance', distance, 'vec', vec)
+  camera.position.sub(vec)
 
   camera.updateProjectionMatrix()
 

--- a/src/components/webgl/cameraUtils2.js
+++ b/src/components/webgl/cameraUtils2.js
@@ -32,6 +32,7 @@ export default function zoomToFitBounds (object, camera, target) {
   const center =  object.boundingSphere.center
   const distance = height / 2 / Math.tan(Math.PI * fov / 360)//center.distanceTo(camera.position) - radius
   const offset = new THREE.Vector3().subVectors(center, camera.position)
+  const targetOffset = new THREE.Vector3().subVectors(center, camera.target)
 
 
   var realHeight = Math.abs(bbox.max.y - bbox.min.y)
@@ -39,13 +40,11 @@ export default function zoomToFitBounds (object, camera, target) {
   //camera.fov = fov
 
   //move camera
-  console.log('offset',offset)
-  //console.log('camera',camera.target, camera.position, camera)
-  camera.position.add(offset)
-  //camera.target.copy(target)
+  console.log('offset',targetOffset)
+  camera.position.add(targetOffset)
+  camera.target.copy(center)
 
   camera.updateProjectionMatrix()
-  camera.toPerspective()
 
 // possible api change, to have function return data instead of mutating anything
 /*vec.addVectors(vec, target)

--- a/src/components/webgl/cameraUtils2.js
+++ b/src/components/webgl/cameraUtils2.js
@@ -5,91 +5,23 @@ export default function zoomToFitBounds (object, camera, target) {
   if (bbox.empty()) {
     return
   }
-  let COG = bbox.center()
 
-  // pointCameraTo(COG, target, camera)
-  // camera.lookAt(COG)
-
-  /*let sphereSize = object.boundingSphere.radius // bbox.size().length() * 0.5
-  let distToCenter = sphereSize / Math.sin(Math.PI / 180.0 * camera.fov * 0.5)
-*/
-  // move the camera backward
-
-  console.log('bbbox', bbox.center())
   target = bbox.center()
-  // let vec = new THREE.Vector3()
-  // compute vector from cam position to target
-  // vec.subVectors(camera.position, target)
-  // set that vector's length to the distance to the center
-  // vec.setLength(distToCenter)
-  // offset camera position by offset distance + target
-  // camera.position.addVectors(vec , target)
 
-  const height = 100
-
-  const correctForDepth = 1.7
   const radius = object.boundingSphere.radius
   const center = object.boundingSphere.center
   const targetOffset = new THREE.Vector3().subVectors(center, camera.target)
 
-  var realHeight = Math.abs(bbox.max.y - bbox.min.y)
-  //  const distance = height / 2 / Math.tan(Math.PI * fov / 360)// center.distanceTo(camera.position) - radius
-
-  // var fov = 2 * Math.atan(realHeight * correctForDepth / ( 2 * distance )) * ( 180 / Math.PI )
-  // camera.fov = fov
-
-  var fov = camera.fov * (Math.PI / 180)
-  // Calculate the camera distance
-  var distance = Math.abs(realHeight / Math.sin(fov / 2))
-
-  //var maxDim = Math.max(w, h)
-  //var aspectRatio = w / h
-  //var distance = maxDim / 2 / aspectRatio / Math.tan(Math.PI * fov / 360)
-
-  // move camera
-  console.log('offset', targetOffset)
+  // move camera to base position
   camera.position.add(targetOffset)
   camera.target.copy(center)
 
+  // and move it away from the boundingSphere of the object
   let vec = new THREE.Vector3()
   vec.subVectors(camera.position, camera.target)
   vec.normalize()
-  vec.setLength(center.distanceTo(camera.position) - radius*4)
-  console.log('distance', distance, 'vec', vec)
+  vec.setLength(center.distanceTo(camera.position) - radius * 4)
   camera.position.sub(vec)
 
   camera.updateProjectionMatrix()
-
-// possible api change, to have function return data instead of mutating anything
-/*vec.addVectors(vec, target)
-
-return {COG,offset:vec}
-
-//in other function ??
-pointCameraTo(COG, target, camera)
-camera.lookAt(COG)*/
-}
-
-/**
- * point the current camera to the center
- * of the graphical object (zoom factor is not affected)
- *
- * the camera is moved in its  x,z plane so that the orientation
- * is not affected either
- */
-export function pointCameraTo (COG, target, camera) {
-  // Refocus camera to the center of the new object
-  let v = new THREE.Vector3()
-  v.subVectors(COG, target)
-
-  camera.position.addVectors(camera.position, v)
-}
-
-// non mutating
-export function positionOfCameraPointedTo (COG, target, camera) {
-  // Refocus camera to the center of the new object
-  let v = new THREE.Vector3()
-  v.subVectors(COG, target)
-
-  return camera.position.clone().addVectors(camera.position, v)
 }

--- a/src/components/webgl/computeBounds2.js
+++ b/src/components/webgl/computeBounds2.js
@@ -1,0 +1,43 @@
+import THREE from 'three'
+
+// FIXME : very temporary , until moving to regl/gl-matrix
+
+export function computeBoundingBox (object, children, force) {
+  var force = force === undefined ? false : force
+
+  if (object.geometry === undefined) {
+    var bbox = new THREE.Box3()
+  } else {
+    if ((! object.geometry.boundingBox) || force) {
+      object.geometry.computeBoundingBox()
+    }
+    var bbox = object.geometry.boundingBox.clone()
+  }
+
+  children.forEach(function(rootChild){
+    rootChild.traverse(function (child) {
+      if (child instanceof THREE.Mesh) {
+        if (child.geometry !== undefined) {
+          if ((! child.geometry.boundingBox) || force) {
+            child.geometry.computeBoundingBox()
+          }
+          var childBox = child.geometry.boundingBox.clone()
+          childBox.translate(child.localToWorld(new THREE.Vector3()))
+          bbox.union(childBox)
+        }
+      }
+    })
+  })
+
+  object.boundingBox = bbox
+  return bbox
+}
+
+export function computeBoundingSphere (object, children, force) {
+  var bbox = new THREE.Box3().setFromObject(object)
+
+  if (object.boundingBox) object.boundingBox.copy(bbox)
+  if (!object.boundingBox) object.boundingBox = bbox
+  const boundingSphere = bbox.getBoundingSphere()
+  return boundingSphere
+}

--- a/src/core/selections/selections.js
+++ b/src/core/selections/selections.js
@@ -2,7 +2,7 @@ import { toArray } from '../../utils/utils'
 import { makeModel, mergeData } from '../../utils/modelUtils'
 
 function selectEntities (state, input) {
-  // log.info("selecting entitites",sentities)
+  // log.info("selecting entitites",input)
   return mergeData(state, {instIds: toArray(input)})
 }
 
@@ -11,17 +11,24 @@ function selectBomEntries (state, input) {
   return mergeData(state, {bomIds: toArray(input)})
 }
 
+function focusOnEntities (state, input) {
+  //console.info('focusing on entitites', input)
+  return mergeData(state, {focusInstIds: toArray(input)})
+}
+
 function selections (actions, source) {
   // /defaults, what else ?
   const defaults = {
     instIds: [],
-    bomIds: []
+    bomIds: [],
+    // for focusing (!== selection)
+    focusInstIds: []
   }
 
   let updateFns = {
     selectEntities,
-    selectBomEntries
-  }
+    selectBomEntries,
+  focusOnEntities}
   return makeModel(defaults, updateFns, actions)
 }
 


### PR DESCRIPTION
As a user I would like to be able to double click on a bom entry to refocus the 3D view on ALL the copies of the given parts

## How to test
- load at least two models, duplicate them and move the copies around
- open the bom
- double click anywhere in a bom entry (line)
- the 3d view should zoom in /out and focus on ALL the copies of the current bom entry, regardless of their count or position