### PR TITLE
fallback color picker

### DIFF
--- a/src/components/EntityInfos/intent.js
+++ b/src/components/EntityInfos/intent.js
@@ -23,6 +23,9 @@ export default function intent (DOM) {
     .distinctUntilChanged()
     .debounce(20)
     .shareReplay(1)
+  .merge(
+    DOM.select('.colorPickerSquare')
+    .events('click').map(e => e.target.dataset.color))
 
   /*const baseStream$ = merge(
       DOM.select('.transformsInput').events('change'),

--- a/src/components/EntityInfos/intent.js
+++ b/src/components/EntityInfos/intent.js
@@ -24,7 +24,7 @@ export default function intent (DOM) {
     .debounce(20)
     .shareReplay(1)
   .merge(
-    DOM.select('.colorPickerSquare')
+    DOM.select('.fallbackPickerSquare')
     .events('click').map(e => e.target.dataset.color))
 
   /*const baseStream$ = merge(

--- a/src/components/EntityInfos/nameAndColor.js
+++ b/src/components/EntityInfos/nameAndColor.js
@@ -1,6 +1,7 @@
 import {html} from 'snabbdom-jsx'
 import Menu from '../widgets/Menu'
 import checkbox from '../widgets/Checkbox'
+import FallbackPicker from '../widgets/ColorPicker/fallbackPicker.js'
 
 const icon = `<svg viewBox="0 0 23 24" preserveAspectRatio="xMidYMid meet" class='icon'
 version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -31,6 +32,17 @@ export function renderNameAndColorUi (state) {
   let meta = data.meta.length > 0 ? data.meta[0] : data.meta
   meta = meta || {name: undefined, color: '#FFFFFF'}
 
+  function getFallbackPicker () {
+    // first check whether the browser supports html5 color input, if not load the fallback picker
+    if (document.getElementById('colorInput')) {
+      let element = document.getElementById('colorInput')
+      if (element.type === 'text') { // non supporting browsers set the input type to text instead of color
+        return FallbackPicker()
+      }
+    }
+    return ''
+  }
+
   const subTools = <span className='nameAndColorSubTools'>
     <div className='formGroup'>
       <span>
@@ -43,9 +55,10 @@ export function renderNameAndColorUi (state) {
       <span>
         <label htmlfor='entityColor' > Color: </label>
         <span className='inputWrapper' style={{'backgroundColor':meta.color}} >
-          <input type='color' name='entityColor' value={meta.color} className='colorInput'/>
+          <input type='color' name='entityColor' value={meta.color} className='colorInput' id= 'colorInput' />
         </span>
       </span>
+      {getFallbackPicker()}
     </div>
   </span>
 

--- a/src/components/widgets/ColorPicker/fallbackPicker.js
+++ b/src/components/widgets/ColorPicker/fallbackPicker.js
@@ -52,7 +52,7 @@ export default function FallbackPicker () {
 
   const colorGrid = getColors()
     .map(function(color){
-      return h('div.colorPickerSquare',{style:{backgroundColor:color},attrs: {'data-color': color}},[])
+      return h('div.fallbackPickerSquare',{style:{backgroundColor:color},attrs: {'data-color': color}},[])
     })
 
   const picker = <div className='colorGridWrapper'>

--- a/src/components/widgets/ColorPicker/fallbackPicker.js
+++ b/src/components/widgets/ColorPicker/fallbackPicker.js
@@ -1,0 +1,62 @@
+import {html} from 'snabbdom-jsx'
+import { h } from '@cycle/dom'
+
+require('./style.css')
+
+export default function FallbackPicker () {
+  const baseColors = {
+    'red': [255, 0, 0],
+    'pink': [255, 0, 255],
+    'blue': [0, 0, 255],
+    'turquois': [0, 255, 255],
+    'green': [0, 255, 0],
+    'yellow': [255, 255, 0],
+    'orange': [255, 102, 0],
+    'black': [0, 0, 0]
+  }
+
+  function componentToHex (rgbPosition) {
+    // translate the seperate rgb postions (0 -> 255) to its hex format
+    var hex = rgbPosition.toString(16)
+    return hex.length === 1 ? '0' + hex : hex
+  }
+
+  function getColors () {
+    // creates a range for every basecolor. Does this by dividing the range (255 per primary color -> rgb)
+    // into steps and adding the steprange for every step untill it all adds up to white (we don't show the last step)
+    const steps = 8
+    const stepRange = 32
+    let htmlCodes = []
+    for (let color in baseColors) {
+      let rgb = baseColors[color] // array
+      let hex = []
+      for (let i = 0; i < steps; i++) { // always 1 less then the number of steps because last step is white for all
+        for (let j = 0; j < 3; j++) {
+          hex[j] = componentToHex(rgb[j])
+
+          // from here we take it up a notch (make the color lighter by adding a the stepRange)
+          if (rgb[j] < 255) {
+            rgb[j] += stepRange
+          }
+          if (rgb[j] > 255) {
+            // fallback for calculation differences because 255 / 66 does not devide to a round number
+            rgb[j] = 255
+          }
+        }
+        let htmlCode = '#' + hex.join('')
+        htmlCodes.push(htmlCode)
+      }
+    }
+    return htmlCodes
+  }
+
+  const colorGrid = getColors()
+    .map(function(color){
+      return h('div.colorPickerSquare',{style:{backgroundColor:color},attrs: {'data-color': color}},[])
+    })
+
+  const picker = <div className='colorGridWrapper'>
+    {colorGrid}
+  </div>
+  return picker
+}

--- a/src/components/widgets/ColorPicker/style.css
+++ b/src/components/widgets/ColorPicker/style.css
@@ -1,0 +1,12 @@
+.colorGridWrapper{
+  width: 100%;
+  margin-top: 20px;
+}
+
+.colorPickerSquare{
+  display: inline-block;
+  margin-bottom: 5px;
+  width: calc(12.5%);
+  height: 20px;
+  cursor: pointer;
+}

--- a/src/components/widgets/ColorPicker/style.css
+++ b/src/components/widgets/ColorPicker/style.css
@@ -3,7 +3,7 @@
   margin-top: 20px;
 }
 
-.colorPickerSquare{
+.fallbackPickerSquare{
   display: inline-block;
   margin-bottom: 5px;
   width: calc(12.5%);


### PR DESCRIPTION
This fallback picker is only used when a browser does not support the html 5 color input. (this is only the case for older ie's and safari). In only those cases a simple 'color picker' is loaded. 

# How to test

- check out this branch and run it
- visit it with any browser and the regular native color picker should just work
- now visit it with safari. It should load the simple color picker as in the image below 
- change the color of a model to see if it works

![screen shot 2016-08-30 at 15 48 33](https://cloud.githubusercontent.com/assets/12695732/18091533/43fd7916-6ec9-11e6-82d8-8d92a42585d8.png)


